### PR TITLE
Create 110-no_ripemd_fix.patch

### DIFF
--- a/net/openssh/patches/110-no_ripemd_fix.patch
+++ b/net/openssh/patches/110-no_ripemd_fix.patch
@@ -1,0 +1,22 @@
+--- a/mac.c
++++ b/mac.c
+@@ -70,8 +70,10 @@
+ #endif
+        { "hmac-md5",                           SSH_EVP, EVP_md5, 0, 0, 0, 0 },
+        { "hmac-md5-96",                        SSH_EVP, EVP_md5, 96, 0, 0, 0 },
++#ifndef OPENSSL_NO_RIPEMD
+        { "hmac-ripemd160",                     SSH_EVP, EVP_ripemd160, 0, 0, 0, 0 },
+        { "hmac-ripemd160@openssh.com",         SSH_EVP, EVP_ripemd160, 0, 0, 0, 0 },
++#endif
+        { "umac-64@openssh.com",                SSH_UMAC, NULL, 0, 128, 64, 0 },
+        { "umac-128@openssh.com",               SSH_UMAC128, NULL, 0, 128, 128, 0 },
+
+@@ -84,7 +86,9 @@
+ #endif
+        { "hmac-md5-etm@openssh.com",           SSH_EVP, EVP_md5, 0, 0, 0, 1 },
+        { "hmac-md5-96-etm@openssh.com",        SSH_EVP, EVP_md5, 96, 0, 0, 1 },
++#ifndef OPENSSL_NO_RIPEMD
+        { "hmac-ripemd160-etm@openssh.com",     SSH_EVP, EVP_ripemd160, 0, 0, 0, 1 },
++#endif
+        { "umac-64-etm@openssh.com",            SSH_UMAC, NULL, 0, 128, 64, 1 },
+        { "umac-128-etm@openssh.com",           SSH_UMAC128, NULL, 0, 128, 128, 1 },


### PR DESCRIPTION
issue: mac.c:73:33: error: 'EVP_ripemd160' undeclared here (not in a function)

I found the following old post: https://github.com/8devices/carambola2/issues/22 but the linked patch file does't work any more. So I fixed the patch file and now it works again.
